### PR TITLE
触摸优化

### DIFF
--- a/Ink Canvas/MainWindow.xaml
+++ b/Ink Canvas/MainWindow.xaml
@@ -524,11 +524,11 @@
                                                Visibility="{Binding Path=Visibility, ElementName=TouchMultiplierSlider, Mode=OneWay}"/>
                                 </StackPanel>
 
-                                <ui:SimpleStackPanel Spacing="8" Margin="0,4,0,4">
-                                    <TextBlock FontSize="14" Text="在下方用笔尖点击以估计触摸大小倍数" Visibility="{Binding Visibility,ElementName=TouchMultiplierSlider}"/>
-                                    <TextBlock Text="数值仅供参考" Foreground="#666666" Visibility="{Binding Visibility,ElementName=TouchMultiplierSlider}"/>
-                                    <Border CornerRadius="4" Height="48" Background="#cccccc" Visibility="{Binding Visibility,ElementName=TouchMultiplierSlider}" TouchDown="BorderCalculateMultiplier_TouchDown"/>
-                                    <TextBlock Name="TextBlockShowCalculatedMultiplier" FontSize="14" Visibility="{Binding Visibility,ElementName=TouchMultiplierSlider}"/>
+                                <ui:SimpleStackPanel Spacing="8" Margin="0,4,0,4" Visibility="{Binding Visibility,ElementName=TouchMultiplierSlider}">
+                                    <TextBlock FontSize="14" Text="在下方用笔尖点击以估计触摸大小倍数"/>
+                                    <TextBlock Text="数值仅供参考" Foreground="#666666"/>
+                                    <Border CornerRadius="4" Height="48" Background="#cccccc" TouchDown="BorderCalculateMultiplier_TouchDown"/>
+                                    <TextBlock Name="TextBlockShowCalculatedMultiplier" FontSize="14"/>
                                 </ui:SimpleStackPanel>
 
                                 <ui:ToggleSwitch Name="ToggleSwitchEraserBindTouchMultiplier" Header="橡皮擦绑定触摸大小倍数" FontFamily="Microsoft YaHei UI" OnContent="开" OffContent="关" IsOn="False" Toggled="ToggleSwitchEraserBindTouchMultiplier_Toggled" Visibility="{Binding Path=Visibility, ElementName=TouchMultiplierSlider, Mode=OneWay}"/>

--- a/Ink Canvas/MainWindow.xaml
+++ b/Ink Canvas/MainWindow.xaml
@@ -498,11 +498,11 @@
                                 <ui:ToggleSwitch Name="ToggleSwitchAutoSaveStrokesInPowerPoint" Header="自动保存幻灯片墨迹" IsOn="True" FontFamily="Microsoft YaHei UI" OnContent="开" OffContent="关" Toggled="ToggleSwitchAutoSaveStrokesInPowerPoint_Toggled"/>
                                 <ui:ToggleSwitch Name="ToggleSwitchNotifyPreviousPage" Header="记忆并提示上次播放位置" IsOn="False" FontFamily="Microsoft YaHei UI" OnContent="开" OffContent="关" Toggled="ToggleSwitchNotifyPreviousPage_Toggled"/>
                                 <ui:ToggleSwitch Name="ToggleSwitchNotifyHiddenPage" Header="提示隐藏幻灯片" IsOn="True" FontFamily="Microsoft YaHei UI" OnContent="开" OffContent="关" Toggled="ToggleSwitchNotifyHiddenPage_Toggled"/>
-                                
+
                                 <ui:ToggleSwitch Name="ToggleSwitchNoStrokeClearInPowerPoint" Header="退出画板模式时不清除笔迹" IsOn="True" FontFamily="Microsoft YaHei UI" OnContent="开" OffContent="关" Toggled="ToggleSwitchNoStrokeClearInPowerPoint_Toggled"/>
                                 <ui:ToggleSwitch Name="ToggleSwitchShowStrokeOnSelectInPowerPoint" Header="退出画板模式时不隐藏笔迹" IsOn="False" FontFamily="Microsoft YaHei UI" OnContent="开" OffContent="关" Toggled="ToggleSwitchShowStrokeOnSelectInPowerPoint_Toggled"/>
                             </ui:SimpleStackPanel>
-                            
+
                         </GroupBox>
                         <GroupBox Header="高级">
                             <ui:SimpleStackPanel Spacing="12">
@@ -523,7 +523,16 @@
                                                FontSize="14" Width="30" HorizontalAlignment="Center"
                                                Visibility="{Binding Path=Visibility, ElementName=TouchMultiplierSlider, Mode=OneWay}"/>
                                 </StackPanel>
+
+                                <ui:SimpleStackPanel Spacing="8" Margin="0,4,0,4">
+                                    <TextBlock FontSize="14" Text="在下方用笔尖点击以估计触摸大小倍数" Visibility="{Binding Visibility,ElementName=TouchMultiplierSlider}"/>
+                                    <TextBlock Text="数值仅供参考" Foreground="#666666" Visibility="{Binding Visibility,ElementName=TouchMultiplierSlider}"/>
+                                    <Border CornerRadius="4" Height="48" Background="#cccccc" Visibility="{Binding Visibility,ElementName=TouchMultiplierSlider}" TouchDown="BorderCalculateMultiplier_TouchDown"/>
+                                    <TextBlock Name="TextBlockShowCalculatedMultiplier" FontSize="14" Visibility="{Binding Visibility,ElementName=TouchMultiplierSlider}"/>
+                                </ui:SimpleStackPanel>
+
                                 <ui:ToggleSwitch Name="ToggleSwitchEraserBindTouchMultiplier" Header="橡皮擦绑定触摸大小倍数" FontFamily="Microsoft YaHei UI" OnContent="开" OffContent="关" IsOn="False" Toggled="ToggleSwitchEraserBindTouchMultiplier_Toggled" Visibility="{Binding Path=Visibility, ElementName=TouchMultiplierSlider, Mode=OneWay}"/>
+                                <ui:ToggleSwitch Name="ToggleSwitchIsQuadIR" Header="四边红外模式" FontFamily="Microsoft YaHei UI" OnContent="开" OffContent="关" Toggled="ToggleSwitchIsQuadIR_Toggled"/>
                                 <ui:ToggleSwitch Name="ToggleSwitchIsLogEnabled" Header="记录日志" FontFamily="Microsoft YaHei UI" OnContent="开" OffContent="关" IsOn="True" Toggled="ToggleSwitchIsLogEnabled_Toggled"/>
                             </ui:SimpleStackPanel>
                         </GroupBox>
@@ -574,7 +583,7 @@
                             <ui:SimpleStackPanel Spacing="12">
                                 <ui:SimpleStackPanel Orientation="Horizontal" Spacing="4">
                                     <TextBlock FontSize="14">
-                                        <Bold>当前版本:</Bold> 
+                                        <Bold>当前版本:</Bold>
                                     </TextBlock>
                                     <TextBlock FontSize="14" Text="" Name="TextBlockVersion"/>
                                 </ui:SimpleStackPanel>
@@ -934,7 +943,7 @@
                 </Viewbox>
             </Grid>
         </Grid>
-        
+
         <Viewbox Name="ViewboxFloatingBar" Margin="100,10,-2000,-200" 
                  HorizontalAlignment="Left" Height="50" VerticalAlignment="Top">
             <Viewbox.LayoutTransform>
@@ -944,7 +953,7 @@
                 <Border Width="36" Height="36" CornerRadius="5" Background="{DynamicResource ToolBarBackground}" BorderThickness="1" BorderBrush="{DynamicResource ToolBarBorderBrush}" MouseDown="SymbolIconEmoji_MouseDown" MouseUp="SymbolIconEmoji_MouseUp">
                     <ui:SimpleStackPanel Margin="0,5,0,5" Spacing="10" Orientation="Horizontal"
                                          HorizontalAlignment="Center">
-                            <ui:SymbolIcon Name="SymbolIconEmoji" Symbol="Emoji2" Foreground="{DynamicResource ToolBarForeground}"/>
+                        <ui:SymbolIcon Name="SymbolIconEmoji" Symbol="Emoji2" Foreground="{DynamicResource ToolBarForeground}"/>
                     </ui:SimpleStackPanel>
                 </Border>
                 <Border Margin="5,0,0,0" Visibility="Visible" Height="36" Name="BorderFloatingBarMainControls" Background="{DynamicResource ToolBarBackground}" CornerRadius="5" BorderThickness="1" BorderBrush="{DynamicResource ToolBarBorderBrush}">

--- a/Ink Canvas/MainWindow.xaml.cs
+++ b/Ink Canvas/MainWindow.xaml.cs
@@ -949,6 +949,8 @@ namespace Ink_Canvas
                     ToggleSwitchIsSpecialScreen.IsOn = false;
                 }
                 TouchMultiplierSlider.Visibility = ToggleSwitchIsSpecialScreen.IsOn ? Visibility.Visible : Visibility.Collapsed;
+
+                ToggleSwitchIsQuadIR.IsOn = Settings.Advanced.IsQuadIR;
             }
             else
             {
@@ -1815,7 +1817,9 @@ namespace Ink_Canvas
         public double GetTouchBoundWidth(TouchEventArgs e)
         {
             var args = e.GetTouchPoint(null).Bounds;
-            double value = args.Width;
+            double value;
+            if (!Settings.Advanced.IsQuadIR) value = args.Width;
+            else value = Math.Sqrt(args.Width * args.Height); //四边红外
             if (Settings.Advanced.IsSpecialScreen) value *= Settings.Advanced.TouchMultiplier;
             return value;
         }
@@ -3129,10 +3133,27 @@ namespace Ink_Canvas
             SaveSettingsToFile();
         }
 
+        private void BorderCalculateMultiplier_TouchDown(object sender, TouchEventArgs e)
+        {
+            var args = e.GetTouchPoint(null).Bounds;
+            double value;
+            if (!Settings.Advanced.IsQuadIR) value = args.Width;
+            else value = Math.Sqrt(args.Width * args.Height); //四边红外
+
+            TextBlockShowCalculatedMultiplier.Text = (5 / (value * 1.1)).ToString();
+        }
+
         private void ToggleSwitchEraserBindTouchMultiplier_Toggled(object sender, RoutedEventArgs e)
         {
             if (!isLoaded) return;
             Settings.Advanced.EraserBindTouchMultiplier = ToggleSwitchEraserBindTouchMultiplier.IsOn;
+            SaveSettingsToFile();
+        }
+
+        private void ToggleSwitchIsQuadIR_Toggled(object sender, RoutedEventArgs e)
+        {
+            if (!isLoaded) return;
+            Settings.Advanced.IsQuadIR = ToggleSwitchIsQuadIR.IsOn;
             SaveSettingsToFile();
         }
 
@@ -6875,7 +6896,7 @@ namespace Ink_Canvas
             {
                 //进入黑板
                 Topmost = false;
-                
+
                 if (BtnPPTSlideShowEnd.Visibility == Visibility.Collapsed)
                 {
                     pointDesktop = new Point(ViewboxFloatingBar.Margin.Left, ViewboxFloatingBar.Margin.Top);

--- a/Ink Canvas/MainWindow.xaml.cs
+++ b/Ink Canvas/MainWindow.xaml.cs
@@ -1794,10 +1794,12 @@ namespace Ink_Canvas
                     }
                     else
                     {
-                        inkCanvas.EraserShape = forcePointEraser ? new EllipseStylusShape(50, 50) : new EllipseStylusShape(5, 5);
-                        //inkCanvas.EraserShape = new RectangleStylusShape(8, 8);
-                        //inkCanvas.EraserShape = new EllipseStylusShape(boundsWidth * 1.5, boundsWidth * 1.5);
-                        inkCanvas.EditingMode = forcePointEraser ? InkCanvasEditingMode.EraseByPoint : InkCanvasEditingMode.EraseByStroke;
+                        //inkCanvas.EraserShape = new RectangleStylusShape(8, 8); //old old
+                        //inkCanvas.EraserShape = forcePointEraser ? new EllipseStylusShape(50, 50) : new EllipseStylusShape(5, 5); //last
+                        //inkCanvas.EraserShape = new EllipseStylusShape(boundsWidth * 1.5, boundsWidth * 1.5); //old old
+                        //inkCanvas.EditingMode = forcePointEraser ? InkCanvasEditingMode.EraseByPoint : InkCanvasEditingMode.EraseByStroke; //last
+                        inkCanvas.EraserShape = new EllipseStylusShape(5, 5);
+                        inkCanvas.EditingMode = InkCanvasEditingMode.EraseByStroke;
                     }
                 }
             }

--- a/Ink Canvas/Settings.cs
+++ b/Ink Canvas/Settings.cs
@@ -144,10 +144,12 @@ namespace Ink_Canvas
     {
         [JsonProperty("isSpecialScreen")]
         public bool IsSpecialScreen { get; set; } = false;
+        [JsonProperty("isQuadIR")]
+        public bool IsQuadIR { get; set; } = false;
         [JsonProperty("touchMultiplier")]
         public double TouchMultiplier { get; set; } = 0.25;
         [JsonProperty("eraserBindTouchMultiplier")]
-        public bool EraserBindTouchMultiplier { get; set; } = false;
+        public bool EraserBindTouchMultiplier { get; set; } = true;
         [JsonProperty("isLogEnabled")]
         public bool IsLogEnabled { get; set; } = true;
     }


### PR DESCRIPTION
### 四边红外模式
- 默认关闭
- 取触摸高度与宽度乘积的平方根
- 在学校测试可以有效减少误擦情况
### 计算触摸倍率
- 在触摸倍率Slider下方的一个Border内用笔尖点击，即可估计触摸倍率
### 橡皮擦大小绑定触摸倍率默认开启
### 指定笔尾擦除为按笔画擦除
- 原先的笔尾擦除是一下按笔画擦除，一下按点擦除，太奇怪了