### PR TITLE
修复部分界面显示问题

### DIFF
--- a/Ink Canvas/MainWindow.xaml
+++ b/Ink Canvas/MainWindow.xaml
@@ -902,7 +902,7 @@
                         </Border>
                         <Border x:Name="PptNavigationBtn" Width="36" Height="36" CornerRadius="5" Background="{DynamicResource ToolBarBackground}" BorderThickness="1" BorderBrush="{DynamicResource ToolBarBorderBrush}">
                             <Grid MouseUp="PPTNavigationBtn_Click">
-                                <TextBlock Name="PptNavigationTextBlock" FontSize="10" Foreground="#FF666666" HorizontalAlignment="Center" VerticalAlignment="Center" Text="0/0" />
+                                <TextBlock Name="PptNavigationTextBlock" FontSize="10" Foreground="{DynamicResource ToolBarForeground}" HorizontalAlignment="Center" VerticalAlignment="Center" Text="0/0" />
                             </Grid>
                         </Border>
                         <Border Width="36" MouseUp="GridPPTControlNext_MouseUp" Height="36" CornerRadius="5" Background="{DynamicResource ToolBarBackground}" BorderThickness="1" BorderBrush="{DynamicResource ToolBarBorderBrush}">

--- a/Ink Canvas/MainWindow.xaml.cs
+++ b/Ink Canvas/MainWindow.xaml.cs
@@ -1458,38 +1458,38 @@ namespace Ink_Canvas
                 inkCanvas.EditingMode = InkCanvasEditingMode.Ink;
                 CancelSingleFingerDragMode();
                 forceEraser = false;
+
+                // 改变选中提示
+                ViewboxBtnColorBlackContent.Visibility = Visibility.Collapsed;
+                ViewboxBtnColorBlueContent.Visibility = Visibility.Collapsed;
+                ViewboxBtnColorGreenContent.Visibility = Visibility.Collapsed;
+                ViewboxBtnColorRedContent.Visibility = Visibility.Collapsed;
+                ViewboxBtnColorYellowContent.Visibility = Visibility.Collapsed;
+                ViewboxBtnColorWhiteContent.Visibility = Visibility.Collapsed;
+                switch (inkColor)
+                {
+                    case 0:
+                        ViewboxBtnColorBlackContent.Visibility = Visibility.Visible;
+                        break;
+                    case 1:
+                        ViewboxBtnColorRedContent.Visibility = Visibility.Visible;
+                        break;
+                    case 2:
+                        ViewboxBtnColorGreenContent.Visibility = Visibility.Visible;
+                        break;
+                    case 3:
+                        ViewboxBtnColorBlueContent.Visibility = Visibility.Visible;
+                        break;
+                    case 4:
+                        ViewboxBtnColorYellowContent.Visibility = Visibility.Visible;
+                        break;
+                    case 5:
+                        ViewboxBtnColorWhiteContent.Visibility = Visibility.Visible;
+                        break;
+                }
             }
 
             isLongPressSelected = false;
-
-            // 改变选中提示
-            ViewboxBtnColorBlackContent.Visibility = Visibility.Collapsed;
-            ViewboxBtnColorBlueContent.Visibility = Visibility.Collapsed;
-            ViewboxBtnColorGreenContent.Visibility = Visibility.Collapsed;
-            ViewboxBtnColorRedContent.Visibility = Visibility.Collapsed;
-            ViewboxBtnColorYellowContent.Visibility = Visibility.Collapsed;
-            ViewboxBtnColorWhiteContent.Visibility = Visibility.Collapsed;
-            switch (inkColor)
-            {
-                case 0:
-                    ViewboxBtnColorBlackContent.Visibility = Visibility.Visible;
-                    break;
-                case 1:
-                    ViewboxBtnColorRedContent.Visibility = Visibility.Visible;
-                    break;
-                case 2:
-                    ViewboxBtnColorGreenContent.Visibility = Visibility.Visible;
-                    break;
-                case 3:
-                    ViewboxBtnColorBlueContent.Visibility = Visibility.Visible;
-                    break;
-                case 4:
-                    ViewboxBtnColorYellowContent.Visibility = Visibility.Visible;
-                    break;
-                case 5:
-                    ViewboxBtnColorWhiteContent.Visibility = Visibility.Visible;
-                    break;
-            }
         }
 
         private void BtnColorBlack_Click(object sender, RoutedEventArgs e)
@@ -6849,6 +6849,7 @@ namespace Ink_Canvas
         {
             BtnSelect_Click(BtnSelect, null);
 
+            ImageEraser.Visibility = Visibility.Visible;
             ViewboxBtnColorBlackContent.Visibility = Visibility.Collapsed;
             ViewboxBtnColorBlueContent.Visibility = Visibility.Collapsed;
             ViewboxBtnColorGreenContent.Visibility = Visibility.Collapsed;


### PR DESCRIPTION
## 深色模式相关
- 修复 PowerPoint 状态下，幻灯片导航按钮上的数字文本的颜色不正确的问题。

## 画板相关
- 修复橡皮状态下进入选择模式，橡皮高亮不消除的问题。

### 可能不属于问题的修复
- 修复选中笔迹之后点击颜色会导致显示「✔️」的问题。
  此问题可能导致与画笔模式混淆，因此提出修复。