### PR TITLE
画笔颜色优化

### DIFF
--- a/Ink Canvas/MainWindow.xaml
+++ b/Ink Canvas/MainWindow.xaml
@@ -598,7 +598,7 @@
                                      <Bold>开发者:</Bold> XY Wang (WXRIW)
                                 </TextBlock>
                                 <TextBlock FontSize="14" TextWrapping="Wrap">
-                                     <Bold>贡献者:</Bold> Kengwang, Raspberry Kan, jiajiaxd, CN-Ironegg, Clover Yan, STBBRD
+                                     <Bold>贡献者:</Bold> Kengwang, Raspberry Kan, jiajiaxd, CN-Ironegg, Clover Yan, ZongziTEK
                                 </TextBlock>
                                 <TextBlock FontSize="14">
                                     <Bold>开源地址:</Bold>

--- a/Ink Canvas/MainWindow.xaml
+++ b/Ink Canvas/MainWindow.xaml
@@ -598,7 +598,7 @@
                                      <Bold>开发者:</Bold> XY Wang (WXRIW)
                                 </TextBlock>
                                 <TextBlock FontSize="14" TextWrapping="Wrap">
-                                     <Bold>贡献者:</Bold> Kengwang, Raspberry Kan, jiajiaxd, CN-Ironegg, Clover Yan, ZongziTEK
+                                     <Bold>贡献者:</Bold> Kengwang, Raspberry Kan, jiajiaxd, CN-Ironegg, Clover Yan, ZongziTEK, ChangSakura
                                 </TextBlock>
                                 <TextBlock FontSize="14">
                                     <Bold>开源地址:</Bold>

--- a/Ink Canvas/MainWindow.xaml.cs
+++ b/Ink Canvas/MainWindow.xaml.cs
@@ -1236,19 +1236,19 @@ namespace Ink_Canvas
                 }
                 else if (inkColor == 1)
                 {
-                    BtnColorRed_Click(null,null);
+                    BtnColorRed_Click(null, null);
                 }
                 else if (inkColor == 2)
                 {
-                    BtnColorGreen_Click(null,null);
+                    BtnColorGreen_Click(null, null);
                 }
                 else if (inkColor == 3)
                 {
-                    BtnColorBlue_Click(null,null);
+                    BtnColorBlue_Click(null, null);
                 }
                 else if (inkColor == 4)
                 {
-                    BtnColorYellow_Click(null,null);
+                    BtnColorYellow_Click(null, null);
                 }
             }
             else
@@ -6905,6 +6905,8 @@ namespace Ink_Canvas
 
         private async void SymbolIconCursor_Click(object sender, RoutedEventArgs e)
         {
+            SetDarkColors();
+
             if (currentMode != 0)
             {
                 ImageBlackboard_MouseUp(null, null);
@@ -6986,6 +6988,9 @@ namespace Ink_Canvas
             if (currentMode == 0)
             {
                 //进入黑板
+                if (Settings.Canvas.UsingWhiteboard) SetDarkColors();   //在白板上用深色墨迹
+                else SetLightColors();  //在黑板上用浅色墨迹
+
                 Topmost = false;
 
                 if (BtnPPTSlideShowEnd.Visibility == Visibility.Collapsed)
@@ -7018,6 +7023,8 @@ namespace Ink_Canvas
             else
             {
                 //关闭黑板
+                SetDarkColors();
+
                 Topmost = true;
 
                 if (isInMultiTouchMode) BorderMultiTouchMode_MouseUp(null, null);

--- a/Ink Canvas/MainWindow.xaml.cs
+++ b/Ink Canvas/MainWindow.xaml.cs
@@ -46,7 +46,6 @@ namespace Ink_Canvas
         {
             InitializeComponent();
 
-
             BorderSettings.Visibility = Visibility.Collapsed;
             StackPanelToolButtons.Visibility = Visibility.Collapsed;
             BorderDrawShape.Visibility = Visibility.Collapsed;
@@ -148,22 +147,21 @@ namespace Ink_Canvas
                 }
             }
             catch { }
-        }
+        }        
 
         #endregion Timer
 
         #region Ink Canvas Functions
-
-        Color Ink_DefaultColor = Colors.Red;
-
+        
         DrawingAttributes drawingAttributes;
         private void loadPenCanvas()
         {
+            SetDarkColors();
             try
             {
                 //drawingAttributes = new DrawingAttributes();
                 drawingAttributes = inkCanvas.DefaultDrawingAttributes;
-                drawingAttributes.Color = Ink_DefaultColor;
+                drawingAttributes.Color = ((SolidColorBrush)BtnColorRed.Background).Color;
 
                 drawingAttributes.Height = 2.5;
                 drawingAttributes.Width = 2.5;
@@ -1557,13 +1555,20 @@ namespace Ink_Canvas
         {
             inkColor = 1;
             forceEraser = false;
-            if (BtnSwitchTheme.Content.ToString() == "浅色")
+            if (!isLastSwitchColorByFloatBar)
             {
-                SetDarkColors();    //在浅色背景上使用深色墨迹
+                if (BtnSwitchTheme.Content.ToString() == "浅色")
+                {
+                    SetDarkColors();    //在浅色背景上使用深色墨迹
+                }
+                else
+                {
+                    SetLightColors();    //在深色背景上使用浅色墨迹
+                }
             }
             else
             {
-                SetLightColors();    //在深色背景上使用浅色墨迹
+                isLastSwitchColorByFloatBar = false;
             }
             inkCanvas.DefaultDrawingAttributes.Color = ((SolidColorBrush)BtnColorRed.Background).Color;
 
@@ -1574,13 +1579,20 @@ namespace Ink_Canvas
         {
             inkColor = 2;
             forceEraser = false;
-            if (BtnSwitchTheme.Content.ToString() == "浅色")
+            if (!isLastSwitchColorByFloatBar)
             {
-                SetDarkColors();    //在浅色背景上使用深色墨迹
+                if (BtnSwitchTheme.Content.ToString() == "浅色")
+                {
+                    SetDarkColors();    //在浅色背景上使用深色墨迹
+                }
+                else
+                {
+                    SetLightColors();    //在深色背景上使用浅色墨迹
+                }
             }
             else
             {
-                SetLightColors();    //在深色背景上使用浅色墨迹
+                isLastSwitchColorByFloatBar = false;
             }
             inkCanvas.DefaultDrawingAttributes.Color = ((SolidColorBrush)BtnColorGreen.Background).Color;
 
@@ -1591,6 +1603,21 @@ namespace Ink_Canvas
         {
             inkColor = 3;
             forceEraser = false;
+            if (!isLastSwitchColorByFloatBar)
+            {
+                if (BtnSwitchTheme.Content.ToString() == "浅色")
+                {
+                    SetDarkColors();    //在浅色背景上使用深色墨迹
+                }
+                else
+                {
+                    SetLightColors();    //在深色背景上使用浅色墨迹
+                }
+            }
+            else
+            {
+                isLastSwitchColorByFloatBar = false;
+            }
             inkCanvas.DefaultDrawingAttributes.Color = ((SolidColorBrush)BtnColorBlue.Background).Color;
 
             ColorSwitchCheck();
@@ -1600,13 +1627,20 @@ namespace Ink_Canvas
         {
             inkColor = 4;
             forceEraser = false;
-            if (BtnSwitchTheme.Content.ToString() == "浅色")
+            if (!isLastSwitchColorByFloatBar)
             {
-                SetDarkColors();    //在浅色背景上使用深色墨迹
+                if (BtnSwitchTheme.Content.ToString() == "浅色")
+                {
+                    SetDarkColors();    //在浅色背景上使用深色墨迹
+                }
+                else
+                {
+                    SetLightColors();    //在深色背景上使用浅色墨迹
+                }
             }
             else
             {
-                SetLightColors();    //在深色背景上使用浅色墨迹
+                isLastSwitchColorByFloatBar = false;
             }
             inkCanvas.DefaultDrawingAttributes.Color = ((SolidColorBrush)BtnColorYellow.Background).Color;
 
@@ -5864,6 +5898,7 @@ namespace Ink_Canvas
             {
                 BtnColorRed.Background = new SolidColorBrush(StringToColor("#FFFF3333"));
                 BtnColorGreen.Background = new SolidColorBrush(StringToColor("#FF1ED760"));
+                BtnColorBlue.Background = new SolidColorBrush(StringToColor("#FF239AD6"));
                 BtnColorYellow.Background = new SolidColorBrush(StringToColor("#FFFFC000"));
             }
         }
@@ -5882,6 +5917,7 @@ namespace Ink_Canvas
             {
                 BtnColorRed.Background = new SolidColorBrush(Colors.Red);
                 BtnColorGreen.Background = new SolidColorBrush(StringToColor("#FF169141"));
+                BtnColorBlue.Background = new SolidColorBrush(StringToColor("#FF239AD6"));
                 BtnColorYellow.Background = new SolidColorBrush(StringToColor("#FFF38B00"));
             }
         }
@@ -6853,6 +6889,8 @@ namespace Ink_Canvas
             BorderTools.Visibility = Visibility.Collapsed;
         }
 
+        bool isLastSwitchColorByFloatBar = false;
+
         private void BorderPenColorBlack_MouseUp(object sender, MouseButtonEventArgs e)
         {
             BtnColorBlack_Click(BtnColorBlack, null);
@@ -6861,24 +6899,28 @@ namespace Ink_Canvas
 
         private void BorderPenColorRed_MouseUp(object sender, MouseButtonEventArgs e)
         {
+            isLastSwitchColorByFloatBar = true;
             BtnColorRed_Click(BtnColorRed, null);
             HideSubPanels();
         }
 
         private void BorderPenColorGreen_MouseUp(object sender, MouseButtonEventArgs e)
         {
+            isLastSwitchColorByFloatBar = true;
             BtnColorGreen_Click(BtnColorGreen, null);
             HideSubPanels();
         }
 
         private void BorderPenColorBlue_MouseUp(object sender, MouseButtonEventArgs e)
         {
+            isLastSwitchColorByFloatBar = true;
             BtnColorBlue_Click(BtnColorBlue, null);
             HideSubPanels();
         }
 
         private void BorderPenColorYellow_MouseUp(object sender, MouseButtonEventArgs e)
         {
+            isLastSwitchColorByFloatBar = true;
             BtnColorYellow_Click(BtnColorYellow, null);
             HideSubPanels();
         }

--- a/Ink Canvas/MainWindow.xaml.cs
+++ b/Ink Canvas/MainWindow.xaml.cs
@@ -534,7 +534,7 @@ namespace Ink_Canvas
             if (!CloseIsFromButton)
             {
                 e.Cancel = true;
-                if (MessageBox.Show("是否继续关闭 Ink Canvas 画板，这将丢失当前未保存的工作。", "Ink Canvas 画板", MessageBoxButton.OKCancel,MessageBoxImage.Warning) == MessageBoxResult.OK)
+                if (MessageBox.Show("是否继续关闭 Ink Canvas 画板，这将丢失当前未保存的工作。", "Ink Canvas 画板", MessageBoxButton.OKCancel, MessageBoxImage.Warning) == MessageBoxResult.OK)
                 {
                     if (MessageBox.Show("真的狠心关闭 Ink Canvas 画板吗？", "Ink Canvas 画板", MessageBoxButton.OKCancel, MessageBoxImage.Error) == MessageBoxResult.OK)
                     {

--- a/Ink Canvas/MainWindow.xaml.cs
+++ b/Ink Canvas/MainWindow.xaml.cs
@@ -1349,7 +1349,7 @@ namespace Ink_Canvas
 
 
                 // Auto-clear Strokes
-                // 很烦, 要重新来, 要等待截图完成再清理笔记
+                // 很烦, 要重新来, 要等待截图完成再清理笔迹
                 if (BtnPPTSlideShowEnd.Visibility != Visibility.Visible)
                 {
                     if (isLoaded && Settings.Automation.IsAutoClearWhenExitingWritingMode)

--- a/Ink Canvas/MainWindow.xaml.cs
+++ b/Ink Canvas/MainWindow.xaml.cs
@@ -147,12 +147,12 @@ namespace Ink_Canvas
                 }
             }
             catch { }
-        }        
+        }
 
         #endregion Timer
 
         #region Ink Canvas Functions
-        
+
         DrawingAttributes drawingAttributes;
         private void loadPenCanvas()
         {
@@ -5888,11 +5888,15 @@ namespace Ink_Canvas
         {
             if (File.Exists(App.RootPath + "Colors\\Light.ini"))
             {
-                string[] lightColors = File.ReadAllLines(App.RootPath + "Colors\\Light.ini");
-                BtnColorRed.Background = new SolidColorBrush(StringToColor(lightColors[0]));
-                BtnColorGreen.Background = new SolidColorBrush(StringToColor(lightColors[1]));
-                BtnColorBlue.Background = new SolidColorBrush(StringToColor(lightColors[2]));
-                BtnColorYellow.Background = new SolidColorBrush(StringToColor(lightColors[3]));
+                try
+                {
+                    string[] lightColors = File.ReadAllLines(App.RootPath + "Colors\\Light.ini");
+                    BtnColorRed.Background = new SolidColorBrush(StringToColor(lightColors[0]));
+                    BtnColorGreen.Background = new SolidColorBrush(StringToColor(lightColors[1]));
+                    BtnColorBlue.Background = new SolidColorBrush(StringToColor(lightColors[2]));
+                    BtnColorYellow.Background = new SolidColorBrush(StringToColor(lightColors[3]));
+                }
+                catch (Exception) { ShowNotification("读取亮色画笔颜色配置文件时遇到问题"); }
             }
             else
             {
@@ -5907,11 +5911,15 @@ namespace Ink_Canvas
         {
             if (File.Exists(App.RootPath + "Colors\\Dark.ini"))
             {
-                string[] darkColors = File.ReadAllLines(App.RootPath + "Colors\\Dark.ini");
-                BtnColorRed.Background = new SolidColorBrush(StringToColor(darkColors[0]));
-                BtnColorGreen.Background = new SolidColorBrush(StringToColor(darkColors[1]));
-                BtnColorBlue.Background = new SolidColorBrush(StringToColor(darkColors[2]));
-                BtnColorYellow.Background = new SolidColorBrush(StringToColor(darkColors[3]));
+                try
+                {
+                    string[] darkColors = File.ReadAllLines(App.RootPath + "Colors\\Dark.ini");
+                    BtnColorRed.Background = new SolidColorBrush(StringToColor(darkColors[0]));
+                    BtnColorGreen.Background = new SolidColorBrush(StringToColor(darkColors[1]));
+                    BtnColorBlue.Background = new SolidColorBrush(StringToColor(darkColors[2]));
+                    BtnColorYellow.Background = new SolidColorBrush(StringToColor(darkColors[3]));
+                }
+                catch (Exception) { ShowNotification("读取深色画笔颜色配置文件时遇到问题"); }
             }
             else
             {

--- a/Ink Canvas/MainWindow.xaml.cs
+++ b/Ink Canvas/MainWindow.xaml.cs
@@ -534,7 +534,7 @@ namespace Ink_Canvas
             if (!CloseIsFromButton)
             {
                 e.Cancel = true;
-                if (MessageBox.Show("是否继续关闭 Ink Canvas 画板，这将丢失当前未保存的工作。", "Ink Canvas 画板", MessageBoxButton.OKCancel) == MessageBoxResult.OK)
+                if (MessageBox.Show("是否继续关闭 Ink Canvas 画板，这将丢失当前未保存的工作。", "Ink Canvas 画板", MessageBoxButton.OKCancel,MessageBoxImage.Warning) == MessageBoxResult.OK)
                 {
                     if (MessageBox.Show("真的狠心关闭 Ink Canvas 画板吗？", "Ink Canvas 画板", MessageBoxButton.OKCancel, MessageBoxImage.Error) == MessageBoxResult.OK)
                     {
@@ -6987,8 +6987,6 @@ namespace Ink_Canvas
 
         private async void SymbolIconCursor_Click(object sender, RoutedEventArgs e)
         {
-            SetDarkColors();
-
             if (currentMode != 0)
             {
                 ImageBlackboard_MouseUp(null, null);
@@ -7006,6 +7004,8 @@ namespace Ink_Canvas
                     }
                 }
             }
+
+            SetDarkColors();
         }
 
         private void SymbolIconDelete_MouseUp(object sender, MouseButtonEventArgs e)

--- a/Ink Canvas/MainWindow.xaml.cs
+++ b/Ink Canvas/MainWindow.xaml.cs
@@ -1229,17 +1229,26 @@ namespace Ink_Canvas
                 BtnExit.Foreground = Brushes.White;
                 GridBackgroundCover.Background = new SolidColorBrush(StringToColor("#FFF2F2F2"));
                 ThemeManager.Current.ApplicationTheme = ApplicationTheme.Dark;
+                SetDarkColors();    //在浅色背景上使用深色墨迹
                 if (inkColor == 0)
                 {
                     inkCanvas.DefaultDrawingAttributes.Color = Colors.White;
                 }
+                else if (inkColor == 1)
+                {
+                    BtnColorRed_Click(null,null);
+                }
                 else if (inkColor == 2)
                 {
-                    inkCanvas.DefaultDrawingAttributes.Color = StringToColor("#FF1ED760");
+                    BtnColorGreen_Click(null,null);
+                }
+                else if (inkColor == 3)
+                {
+                    BtnColorBlue_Click(null,null);
                 }
                 else if (inkColor == 4)
                 {
-                    inkCanvas.DefaultDrawingAttributes.Color = StringToColor("#FFFFC000");
+                    BtnColorYellow_Click(null,null);
                 }
             }
             else
@@ -1252,17 +1261,26 @@ namespace Ink_Canvas
                 BtnExit.Foreground = Brushes.Black;
                 GridBackgroundCover.Background = new SolidColorBrush(StringToColor("#FF1A1A1A"));
                 ThemeManager.Current.ApplicationTheme = ApplicationTheme.Light;
+                SetLightColors();   //在深色背景上使用浅色墨迹
                 if (inkColor == 0)
                 {
-                    inkCanvas.DefaultDrawingAttributes.Color = Colors.Black;
+                    inkCanvas.DefaultDrawingAttributes.Color = Colors.White;
+                }
+                else if (inkColor == 1)
+                {
+                    BtnColorRed_Click(null, null);
                 }
                 else if (inkColor == 2)
                 {
-                    inkCanvas.DefaultDrawingAttributes.Color = StringToColor("#FF169141");
+                    BtnColorGreen_Click(null, null);
+                }
+                else if (inkColor == 3)
+                {
+                    BtnColorBlue_Click(null, null);
                 }
                 else if (inkColor == 4)
                 {
-                    inkCanvas.DefaultDrawingAttributes.Color = StringToColor("#FFF38B00");
+                    BtnColorYellow_Click(null, null);
                 }
             }
             if (!Settings.Appearance.IsTransparentButtonBackground)
@@ -1539,17 +1557,15 @@ namespace Ink_Canvas
         {
             inkColor = 1;
             forceEraser = false;
-            inkCanvas.DefaultDrawingAttributes.Color = Colors.Red;
             if (BtnSwitchTheme.Content.ToString() == "浅色")
             {
-                inkCanvas.DefaultDrawingAttributes.Color = StringToColor("#FFFF3333");
-                BtnColorRed.Background = new SolidColorBrush(StringToColor("#FFFF3333"));
+                SetDarkColors();    //在浅色背景上使用深色墨迹
             }
             else
             {
-                inkCanvas.DefaultDrawingAttributes.Color = Colors.Red;
-                BtnColorRed.Background = Brushes.Red;
+                SetLightColors();    //在深色背景上使用浅色墨迹
             }
+            inkCanvas.DefaultDrawingAttributes.Color = ((SolidColorBrush)BtnColorRed.Background).Color;
 
             ColorSwitchCheck();
         }
@@ -1560,14 +1576,13 @@ namespace Ink_Canvas
             forceEraser = false;
             if (BtnSwitchTheme.Content.ToString() == "浅色")
             {
-                inkCanvas.DefaultDrawingAttributes.Color = StringToColor("#FF1ED760");
-                BtnColorGreen.Background = new SolidColorBrush(StringToColor("#FF1ED760"));
+                SetDarkColors();    //在浅色背景上使用深色墨迹
             }
             else
             {
-                inkCanvas.DefaultDrawingAttributes.Color = StringToColor("#FF169141");
-                BtnColorGreen.Background = new SolidColorBrush(StringToColor("#FF169141"));
+                SetLightColors();    //在深色背景上使用浅色墨迹
             }
+            inkCanvas.DefaultDrawingAttributes.Color = ((SolidColorBrush)BtnColorGreen.Background).Color;
 
             ColorSwitchCheck();
         }
@@ -1576,7 +1591,7 @@ namespace Ink_Canvas
         {
             inkColor = 3;
             forceEraser = false;
-            inkCanvas.DefaultDrawingAttributes.Color = StringToColor("#FF239AD6");
+            inkCanvas.DefaultDrawingAttributes.Color = ((SolidColorBrush)BtnColorBlue.Background).Color;
 
             ColorSwitchCheck();
         }
@@ -1587,14 +1602,13 @@ namespace Ink_Canvas
             forceEraser = false;
             if (BtnSwitchTheme.Content.ToString() == "浅色")
             {
-                inkCanvas.DefaultDrawingAttributes.Color = StringToColor("#FFFFC000");
-                BtnColorYellow.Background = new SolidColorBrush(StringToColor("#FFFFC000"));
+                SetDarkColors();    //在浅色背景上使用深色墨迹
             }
             else
             {
-                inkCanvas.DefaultDrawingAttributes.Color = StringToColor("#FFF38B00");
-                BtnColorYellow.Background = new SolidColorBrush(StringToColor("#FFF38B00"));
+                SetLightColors();    //在深色背景上使用浅色墨迹
             }
+            inkCanvas.DefaultDrawingAttributes.Color = ((SolidColorBrush)BtnColorYellow.Background).Color;
 
             ColorSwitchCheck();
         }
@@ -2868,8 +2882,8 @@ namespace Ink_Canvas
             Settings.Canvas.EraserSize = ComboBoxEraserSize.SelectedIndex;
             SaveSettingsToFile();
         }
-        
-        
+
+
         private void ComboBoxEraserType_OnSelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             if (!isLoaded) return;
@@ -5833,6 +5847,42 @@ namespace Ink_Canvas
             else
             {
                 BtnWhiteBoardDelete.IsEnabled = true;
+            }
+        }
+
+        private void SetLightColors()
+        {
+            if (File.Exists(App.RootPath + "Colors\\Light.ini"))
+            {
+                string[] lightColors = File.ReadAllLines(App.RootPath + "Colors\\Light.ini");
+                BtnColorRed.Background = new SolidColorBrush(StringToColor(lightColors[0]));
+                BtnColorGreen.Background = new SolidColorBrush(StringToColor(lightColors[1]));
+                BtnColorBlue.Background = new SolidColorBrush(StringToColor(lightColors[2]));
+                BtnColorYellow.Background = new SolidColorBrush(StringToColor(lightColors[3]));
+            }
+            else
+            {
+                BtnColorRed.Background = new SolidColorBrush(StringToColor("#FFFF3333"));
+                BtnColorGreen.Background = new SolidColorBrush(StringToColor("#FF1ED760"));
+                BtnColorYellow.Background = new SolidColorBrush(StringToColor("#FFFFC000"));
+            }
+        }
+
+        private void SetDarkColors()
+        {
+            if (File.Exists(App.RootPath + "Colors\\Dark.ini"))
+            {
+                string[] darkColors = File.ReadAllLines(App.RootPath + "Colors\\Dark.ini");
+                BtnColorRed.Background = new SolidColorBrush(StringToColor(darkColors[0]));
+                BtnColorGreen.Background = new SolidColorBrush(StringToColor(darkColors[1]));
+                BtnColorBlue.Background = new SolidColorBrush(StringToColor(darkColors[2]));
+                BtnColorYellow.Background = new SolidColorBrush(StringToColor(darkColors[3]));
+            }
+            else
+            {
+                BtnColorRed.Background = new SolidColorBrush(Colors.Red);
+                BtnColorGreen.Background = new SolidColorBrush(StringToColor("#FF169141"));
+                BtnColorYellow.Background = new SolidColorBrush(StringToColor("#FFF38B00"));
             }
         }
 

--- a/Ink Canvas/MainWindow.xaml.cs
+++ b/Ink Canvas/MainWindow.xaml.cs
@@ -534,7 +534,7 @@ namespace Ink_Canvas
             if (!CloseIsFromButton)
             {
                 e.Cancel = true;
-                if (MessageBox.Show("是否继续关闭 Ink Canvas 画板，这将丢失当前未保存的工作。", "Ink Canvas 画板", MessageBoxButton.OKCancel, MessageBoxImage.Warning) == MessageBoxResult.OK)
+                if (MessageBox.Show("是否继续关闭 Ink Canvas 画板，这将丢失当前未保存的工作。", "Ink Canvas 画板", MessageBoxButton.OKCancel) == MessageBoxResult.OK)
                 {
                     if (MessageBox.Show("真的狠心关闭 Ink Canvas 画板吗？", "Ink Canvas 画板", MessageBoxButton.OKCancel, MessageBoxImage.Error) == MessageBoxResult.OK)
                     {

--- a/Ink Canvas/MainWindow.xaml.cs
+++ b/Ink Canvas/MainWindow.xaml.cs
@@ -306,7 +306,7 @@ namespace Ink_Canvas
         {
             if (ImageEraserMask.Visibility == Visibility.Visible)
             {
-                BtnColorRed_Click(sender, null);
+                BorderPenColorRed_MouseUp(null, null);
             }
             else
             {

--- a/Ink Canvas/MainWindow.xaml.cs
+++ b/Ink Canvas/MainWindow.xaml.cs
@@ -6988,9 +6988,6 @@ namespace Ink_Canvas
             if (currentMode == 0)
             {
                 //进入黑板
-                if (Settings.Canvas.UsingWhiteboard) SetDarkColors();   //在白板上用深色墨迹
-                else SetLightColors();  //在黑板上用浅色墨迹
-
                 Topmost = false;
 
                 if (BtnPPTSlideShowEnd.Visibility == Visibility.Collapsed)
@@ -7019,12 +7016,13 @@ namespace Ink_Canvas
                 {
                     BorderPenColorWhite_MouseUp(BorderPenColorWhite, null);
                 }
+
+                if (Settings.Canvas.UsingWhiteboard) SetDarkColors();   //在白板上用深色墨迹
+                else SetLightColors();  //在黑板上用浅色墨迹
             }
             else
             {
                 //关闭黑板
-                SetDarkColors();
-
                 Topmost = true;
 
                 if (isInMultiTouchMode) BorderMultiTouchMode_MouseUp(null, null);
@@ -7049,6 +7047,8 @@ namespace Ink_Canvas
                     })).Start();
                 }
                 BorderPenColorRed_MouseUp(BorderPenColorRed, null);
+
+                SetDarkColors();
             }
 
             BtnSwitch_Click(BtnSwitch, null);


### PR DESCRIPTION
### 自定义画笔颜色
当配置文件 Colors/Dark.ini 或 Colors/Light.ini 存在时，指定工具栏中四个彩色画笔颜色为配置文件中的颜色
### 画笔颜色深色/浅色切换
- 当配置文件存在时，根据配置文件设置深色浅色各四个彩色画笔颜色；当配置文件不存在时，使用 Ink Canvas 画板默认的深色与浅色的彩色画笔颜色
- 在 3.x 浮动工具栏中进入屏幕批注模式或白板模式时，使用深色画笔；进入黑板模式时，使用浅色画笔
- 在 2.x 旧 UI 中使用新的深浅色切换方法
### 颜色配置文件
#### 介绍
- Colors/Dark.ini 和 Colors/Light.ini
- 一行一个颜色，一共四个，分别对应四个彩色画笔颜色
#### 范例
#FFFF00FF
#FF72EEFF
#FF008DFA
#FFFFF154
### 缺陷
我没做图形化自定义颜色工具