### PR TITLE
[fix] Unexpected eraser size; values for two settings options not updated

### DIFF
--- a/Ink Canvas/MainWindow.xaml
+++ b/Ink Canvas/MainWindow.xaml
@@ -598,7 +598,7 @@
                                      <Bold>开发者:</Bold> XY Wang (WXRIW)
                                 </TextBlock>
                                 <TextBlock FontSize="14" TextWrapping="Wrap">
-                                     <Bold>贡献者:</Bold> Kengwang, Raspberry Kan, jiajiaxd, CN-Ironegg, Clover Yan, STBBRD
+                                     <Bold>贡献者:</Bold> Kengwang, Raspberry Kan, jiajiaxd, CN-Ironegg, Clover Yan, STBBRD, ChangSakura
                                 </TextBlock>
                                 <TextBlock FontSize="14">
                                     <Bold>开源地址:</Bold>

--- a/Ink Canvas/MainWindow.xaml.cs
+++ b/Ink Canvas/MainWindow.xaml.cs
@@ -702,6 +702,14 @@ namespace Ink_Canvas
             {
                 ToggleSwitchEnableTwoFingerZoom.IsOn = false;
             }
+            if (Settings.Gesture.IsEnableTwoFingerTranslate)
+            {
+                ToggleSwitchEnableTwoFingerTranslate.IsOn = true;
+            }
+            else
+            {
+                ToggleSwitchEnableTwoFingerTranslate.IsOn = false;
+            }
             if (Settings.Gesture.IsEnableTwoFingerRotation)
             {
                 ToggleSwitchEnableTwoFingerRotation.IsOn = true;
@@ -761,6 +769,8 @@ namespace Ink_Canvas
                 ComboBoxPenStyle.SelectedIndex = Settings.Canvas.InkStyle;
 
                 ComboBoxEraserSize.SelectedIndex = Settings.Canvas.EraserSize;
+
+                ComboBoxHyperbolaAsymptoteOption.SelectedIndex = (int)Settings.Canvas.HyperbolaAsymptoteOption;
             }
             else
             {
@@ -1045,9 +1055,9 @@ namespace Ink_Canvas
                     forcePointEraser = false;
                     break;
             }
+            inkCanvas.EraserShape = forcePointEraser ? new EllipseStylusShape(50, 50) : new EllipseStylusShape(5, 5);
             inkCanvas.EditingMode =
                 forcePointEraser ? InkCanvasEditingMode.EraseByPoint : InkCanvasEditingMode.EraseByStroke;
-            inkCanvas.EraserShape = forcePointEraser ? new EllipseStylusShape(50, 50) : new EllipseStylusShape(5, 5);
             drawingShapeMode = 0;
             GeometryDrawingEraser.Brush = forcePointEraser
                 ? new SolidColorBrush(Color.FromRgb(0x23, 0xA9, 0xF2))


### PR DESCRIPTION
- Switching to eraser mode immediately after erasing using backhand area sensing results in incorrectly displayed eraser size.
- Values for two settings options not updated when software starts.