### PR TITLE
fix(autosave): 修复白板界面内自动保存时出现错误提示的问题

### DIFF
--- a/Ink Canvas/MainWindow.xaml.cs
+++ b/Ink Canvas/MainWindow.xaml.cs
@@ -5710,15 +5710,15 @@ namespace Ink_Canvas
 
         private void BtnWhiteBoardSwitchNext_Click(object sender, EventArgs e)
         {
-            if (Settings.Automation.IsAutoSaveStrokesAtClear && inkCanvas.Strokes.Count > Settings.Automation.MinimumAutomationStrokeNumber)
-            {
-                SaveScreenShot(true);
-                if (Settings.Automation.IsAutoSaveStrokesAtScreenshot) SaveInkCanvasStrokes(false);
-            }
             if (CurrentWhiteboardIndex >= WhiteboardTotalCount)
             {
                 BtnWhiteBoardAdd_Click(sender, e);
                 return;
+            }
+            if (Settings.Automation.IsAutoSaveStrokesAtClear && inkCanvas.Strokes.Count > Settings.Automation.MinimumAutomationStrokeNumber)
+            {
+                SaveScreenShot(true);
+                if (Settings.Automation.IsAutoSaveStrokesAtScreenshot) SaveInkCanvasStrokes(false);
             }
             SaveStrokes();
 
@@ -7331,9 +7331,9 @@ namespace Ink_Canvas
                         @"\Ink Canvas Strokes\User Saved\" + DateTime.Now.ToString("u").Replace(':', '-') + ".icstk");
                 }
             }
-            catch
+            catch (Exception ex)
             {
-                ShowNotification("墨迹保存失败");
+                ShowNotification($"墨迹保存失败：{ex.Message}");
             }
         }
 


### PR DESCRIPTION
在 `MainWindow.xaml.cs` 中，更新了 `BtnWhiteBoardSwitchNext_Click` 方法，更改了自动保存笔画的条件判断和保存操作。同时，改进了异常处理，提供更详细的错误通知信息，以帮助用户理解保存失败的原因。